### PR TITLE
automatically create destination folder in filecopy command

### DIFF
--- a/src/main/java/com/denizenscript/denizencore/scripts/commands/file/FileCopyCommand.java
+++ b/src/main/java/com/denizenscript/denizencore/scripts/commands/file/FileCopyCommand.java
@@ -137,6 +137,9 @@ public class FileCopyCommand extends AbstractCommand implements Holdable {
                         CoreUtilities.copyDirectory(o, d);
                     }
                     else {
+                        if (!Files.exists(d.toPath().getParent())) {
+                            Files.createDirectories((d.toPath().getParent()));
+                        }
                         Files.copy(o.toPath(), (disdir ? d.toPath().resolve(o.toPath().getFileName()) : d.toPath()));
                     }
                     scriptEntry.addObject("success", new ElementTag("true"));


### PR DESCRIPTION
This will allow users to automatically copy files to deep directories which do not exist yet.